### PR TITLE
returns undefined in first() method when QueryArray is empty.

### DIFF
--- a/Table.gs
+++ b/Table.gs
@@ -399,6 +399,9 @@ GridArray.prototype = cloneObj(Array.prototype);
  * Method to return only the first result of an array. Useful when result of selection.
  */
 GridArray.prototype.first = function() {
+  if (this.length === 0) {
+    return undefined
+  }
   return this[0]
 };
 


### PR DESCRIPTION
As description says.

Following recommendation from @sp-ricard-valverde in https://github.com/socialpoint-labs/sheetfu/issues/13
