### PR TITLE
Fixed issues with filtering and formulas

### DIFF
--- a/Item.gs
+++ b/Item.gs
@@ -197,6 +197,7 @@ Item.prototype.getFieldValue = function(field) {
  */
 Item.prototype.setFieldValue = function(field, value) {
   this.fields[field]["value"] = value;
+  this.fields[field]["formula"] = '';
   return this
 };
 

--- a/Item.gs
+++ b/Item.gs
@@ -52,7 +52,7 @@ Item.prototype.commit = function () {
     var value = this.getFieldValue(field);
     var formula = this.getFieldFormula(field);
 
-    (formula !== "")? rowValues.push(formula) : rowValues.push(value);
+    (formula)? rowValues.push(formula) : rowValues.push(value);
     rowNotes.push(this.getFieldNote(field));
     rowBackgrounds.push(this.getFieldBackground(field));
     rowWraps.push(false);
@@ -83,7 +83,7 @@ Item.prototype.commitValues = function () {
     var value = this.getFieldValue(field);
     var formula = this.getFieldFormula(field);
 
-    (formula !== "")? rowValues.push(formula) : rowValues.push(value);
+    (formula)? rowValues.push(formula) : rowValues.push(value);
   }
 
   var lineRange = this.getLineRange();
@@ -118,10 +118,10 @@ Item.prototype.commitField = function (field) {
     throw "Forbidden to commit this item field. The order of the grid it is associated to has changed."
   }
   var cellRange = this.getFieldRange(field);
-  if (this.getFieldFormula(field) === "") {
-    cellRange.setValue(this.getFieldValue(field));
+  if (this.getFieldFormula(field)) {
+    cellRange.setValue(this.getFieldFormula(field));  
   } else {
-    cellRange.setValue(this.getFieldFormula(field));
+    cellRange.setValue(this.getFieldValue(field));
   }
 
   cellRange.setNote(this.getFieldNote(field));
@@ -140,10 +140,10 @@ Item.prototype.commitFieldValue = function (field) {
     throw "Forbidden to commit this item field. The order of the grid it is associated to has changed."
   }
   var cellRange = this.getFieldRange(field);
-  if (this.getFieldFormula(field) === "") {
-    cellRange.setValue(this.getFieldValue(field));
-  } else {
+  if (this.getFieldFormula(field)) {
     cellRange.setValue(this.getFieldFormula(field));
+  } else {
+    cellRange.setValue(this.getFieldValue(field)); 
   }
 };
 

--- a/Table.gs
+++ b/Table.gs
@@ -190,7 +190,7 @@ Table.prototype.getGridData = function() {
       var value = item.getFieldValue(field);
       var formula = item.getFieldFormula(field);
 
-      (formula !== "")? rowValues.push(formula) : rowValues.push(value);
+      (formula)? rowValues.push(formula) : rowValues.push(value);
       rowNotes.push(item.getFieldNote(field));
       rowBackgrounds.push(item.getFieldBackground(field));
       rowWraps.push(false);
@@ -222,7 +222,7 @@ Table.prototype.getGridValues = function() {
       var value = item.getFieldValue(field);
       var formula = item.getFieldFormula(field);
 
-      (formula !== "")? rowValues.push(formula) : rowValues.push(value);
+      (formula)? rowValues.push(formula) : rowValues.push(value);
     }
     values.push(rowValues);
   }

--- a/Table.gs
+++ b/Table.gs
@@ -131,6 +131,18 @@ Table.prototype.commitValues = function() {
   itemsRange.setValues(values)
 };
 
+/**
+ * Method to commit the fields items values into the associated sheet (regardless if number of items have changed).
+ * @param {Array[]} fields: a list of all fields to commit the values
+ */
+Table.prototype.commitFieldsValues = function(fields) {
+  for (var i=0; i < fields.length; i++) {
+    var values = this.getFieldValues(fields[i]);
+    var fieldRange = this.getFieldRange(fields[i]);
+    fieldRange.clearContent();
+    fieldRange.setValues(values);
+  }
+};
 
 /**
  * Method to get the new Range for the items, based on lenght of Table.items.
@@ -142,6 +154,17 @@ Table.prototype.getItemsRange = function() {
   return sheet.getRange(row, column, this.items.length, this.header.length)
 };
 
+/**
+ * Method to get the new Range for the items, based on lenght of Table.items.
+ * @param {String} field: Field name you want to get the range.
+ */
+Table.prototype.getFieldRange = function(field) {
+  var row = this.gridRange.getRow() + 1;    // +1 to disregard header row
+  var initialColumn = this.gridRange.getColumn();
+  var targetColumn = this.header.indexOf(field);
+  var sheet = this.gridRange.getSheet();
+  return sheet.getRange(row, initialColumn + targetColumn, this.items.length)
+};
 
 /**
  * Method to create both values and notes 2D arrays from grid items.
@@ -206,6 +229,28 @@ Table.prototype.getGridValues = function() {
   return values
 };
 
+/**
+ * Method to create 2D array of the field values of every grid items.
+ * @param {String} field: Field name you want to get the values.
+ * @return {Array[]} The values 2D array.
+ */
+Table.prototype.getFieldValues = function(field) {
+  var values = [];
+
+  for (var i = 0; i < this.items.length; i++) {
+    var rowValues = [];
+    var item = this.items[i];
+
+    var j = this.header.indexOf(field);
+    var field = this.header[j];
+    var value = item.getFieldValue(field);
+    var formula = item.getFieldFormula(field);
+
+    (formula)? rowValues.push(formula) : rowValues.push(value);
+    values.push(rowValues);
+  }
+  return values
+};
 
 /**
  * Method to query rows from a Table, given exact match attributes.

--- a/Table.gs
+++ b/Table.gs
@@ -132,19 +132,6 @@ Table.prototype.commitValues = function() {
 };
 
 /**
- * Method to commit the fields items values into the associated sheet (regardless if number of items have changed).
- * @param {Array[]} fields: a list of all fields to commit the values
- */
-Table.prototype.commitFieldsValues = function(fields) {
-  for (var i=0; i < fields.length; i++) {
-    var values = this.getFieldValues(fields[i]);
-    var fieldRange = this.getFieldRange(fields[i]);
-    fieldRange.clearContent();
-    fieldRange.setValues(values);
-  }
-};
-
-/**
  * Method to get the new Range for the items, based on lenght of Table.items.
  */
 Table.prototype.getItemsRange = function() {
@@ -152,18 +139,6 @@ Table.prototype.getItemsRange = function() {
   var column = this.gridRange.getColumn();
   var sheet = this.gridRange.getSheet();
   return sheet.getRange(row, column, this.items.length, this.header.length)
-};
-
-/**
- * Method to get the new Range for the items, based on lenght of Table.items.
- * @param {String} field: Field name you want to get the range.
- */
-Table.prototype.getFieldRange = function(field) {
-  var row = this.gridRange.getRow() + 1;    // +1 to disregard header row
-  var initialColumn = this.gridRange.getColumn();
-  var targetColumn = this.header.indexOf(field);
-  var sheet = this.gridRange.getSheet();
-  return sheet.getRange(row, initialColumn + targetColumn, this.items.length)
 };
 
 /**
@@ -224,29 +199,6 @@ Table.prototype.getGridValues = function() {
 
       (formula)? rowValues.push(formula) : rowValues.push(value);
     }
-    values.push(rowValues);
-  }
-  return values
-};
-
-/**
- * Method to create 2D array of the field values of every grid items.
- * @param {String} field: Field name you want to get the values.
- * @return {Array[]} The values 2D array.
- */
-Table.prototype.getFieldValues = function(field) {
-  var values = [];
-
-  for (var i = 0; i < this.items.length; i++) {
-    var rowValues = [];
-    var item = this.items[i];
-
-    var j = this.header.indexOf(field);
-    var field = this.header[j];
-    var value = item.getFieldValue(field);
-    var formula = item.getFieldFormula(field);
-
-    (formula)? rowValues.push(formula) : rowValues.push(value);
     values.push(rowValues);
   }
   return values

--- a/Table.gs
+++ b/Table.gs
@@ -311,7 +311,7 @@ Table.prototype.updateMany = function(manyItems) {
  * Method to delete all rows in a Table.
  */
 Table.prototype.resetGrid = function() {
-  this.gridRange.clearContent();
+  this.gridRange.clear({contentsOnly: true, skipFilteredRows: true});
   var header = this.getHeaderRange();
   header.setValues([this.header])
 };


### PR DESCRIPTION
1. On commit, `.clearContent()` was clearing all data, but `.setValues()` was applied only in the filtered rows. With `.clear({contentsOnly: true, skipFilteredRows: true})` fix we will be able to work with filtered tables.

2. There was a bug on setting a value where previously there was a formula. Now it works as intended.

3. There was a risk in `(formula !== "")? _ : _ ;` so it has been updated to `(formula)? _ : _ ;`