### PR TITLE
Allow .add method to also accept Item() instances

### DIFF
--- a/item.gs
+++ b/item.gs
@@ -36,22 +36,6 @@ Item.prototype.addField = function(label, value, note, background, formula, font
   }
 };
 
-
-/**
- * Method to convert the item into a JS object, with its attributes being the header fields of the item.
- * @return {Object} itemObject: The object with each of the header/fieldValue pairs of the item.
- */
-Item.prototype.toObject = function() {
-  var itemObject = {};
-  var self = this; // Needed because inside the forEach function, "this" is actually the list that is being looped through
-  this.table.header.forEach( function(headerField) { 
-    var fieldValue = self.getFieldValue(headerField);
-    itemObject[headerField] = fieldValue;
-  });
-  return itemObject;
-};
-
-
 /**
  * Commit a single item line in spreadsheet if the items order has not been changed since instantiating the grid.
  */

--- a/item.gs
+++ b/item.gs
@@ -38,6 +38,21 @@ Item.prototype.addField = function(label, value, note, background, formula, font
 
 
 /**
+ * Method to convert the item into a JS object, with its attributes being the header fields of the item.
+ * @return {Object} itemObject: The object with each of the header/fieldValue pairs of the item.
+ */
+Item.prototype.toObject = function() {
+  var itemObject = {};
+  var self = this; // Needed because inside the forEach function, "this" is actually the list that is being looped through
+  this.table.header.forEach( function(headerField) { 
+    var fieldValue = self.getFieldValue(headerField);
+    itemObject[headerField] = fieldValue;
+  });
+  return itemObject;
+};
+
+
+/**
  * Commit a single item line in spreadsheet if the items order has not been changed since instantiating the grid.
  */
 Item.prototype.commit = function () {

--- a/table.gs
+++ b/table.gs
@@ -372,9 +372,18 @@ Table.prototype.getHeaderRange = function() {
 
 /**
  * Method to add a new item into the Table. Add the item also to index if there is an index.
- * @param {object} raw_item: an object item containing only values. Field must be matching header values.
+ * @param {object} input_item: an object item containing only values, or an instance of Item. Field must be matching header values.
  */
-Table.prototype.add = function(raw_item) { 
+Table.prototype.add = function(input_item) { 
+  
+  var raw_item = input_item;
+  if(input_item instanceof Item) {
+    raw_item = {}
+    for (var field in input_item.fields) { 
+      raw_item[field] = input_item.getFieldValue(field); 
+    }
+  }
+  
   var newItem = new Item(this.items.length, this.header, this.gridRange.getRow(), this.gridRange.getColumn(), this.gridRange.getSheet());
 
   for (var i = 0; i < this.header.length; i++) {


### PR DESCRIPTION
I think this is a useful method to have, to get an item as a plain javascript object in a {header: fieldValue} pair style, which you can easily loop through with for(var i in object)