### PR TITLE
Fixed sortBy of Dates

### DIFF
--- a/table.gs
+++ b/table.gs
@@ -415,14 +415,12 @@ Table.prototype.add = function(input_item) {
  */
 Table.prototype.sortBy = function(key, ascending) {
 
-  this.items.sort(function(a, b){
-
+  this.items.sort(function(a, b) {
     if (!isNaN(Date.parse(a.getFieldValue(key))) && !isNaN(Date.parse(b.getFieldValue(key)))) {
       var dateA = new Date(a.getFieldValue(key));
-      var keyA = dateA.valueOf();
+      var keyA = dateA.getTime();
       var dateB = new Date(b.getFieldValue(key));
-      var keyB = dateB.valueOf();
-
+      var keyB = dateB.getTime();
     } else {
       var keyA = a.getFieldValue(key);
       var keyB = b.getFieldValue(key);

--- a/table.gs
+++ b/table.gs
@@ -416,7 +416,9 @@ Table.prototype.add = function(input_item) {
 Table.prototype.sortBy = function(key, ascending) {
 
   this.items.sort(function(a, b) {
-    if (!isNaN(Date.parse(a.getFieldValue(key))) && !isNaN(Date.parse(b.getFieldValue(key)))) {
+    var timeStampA = Date.parse(a.getFieldValue(key));
+    var timeStampB = Date.parse(b.getFieldValue(key));
+    if (!isNaN(timeStampA) && !isNaN(timeStampB)) {
       var dateA = new Date(a.getFieldValue(key));
       var keyA = dateA.getTime();
       var dateB = new Date(b.getFieldValue(key));

--- a/table.gs
+++ b/table.gs
@@ -417,9 +417,11 @@ Table.prototype.sortBy = function(key, ascending) {
 
   this.items.sort(function(a, b){
 
-    if (a.getFieldValue(key) instanceof Date) {
-      var keyA = a.getFieldValue(key).getTime();
-      var keyB = b.getFieldValue(key).getTime();
+    if (!isNaN(Date.parse(a.getFieldValue(key))) && !isNaN(Date.parse(b.getFieldValue(key)))) {
+      var dateA = new Date(a.getFieldValue(key));
+      var keyA = dateA.valueOf();
+      var dateB = new Date(b.getFieldValue(key));
+      var keyB = dateB.valueOf();
 
     } else {
       var keyA = a.getFieldValue(key);


### PR DESCRIPTION
The sorting of pseudo-Date objects of GAS was throwing an exception since they don't have the .getTime() method.
Moreover, the sorting of date-like strings was using string sorting instead of date sorting.