### PR TITLE
Adapted method isObject for Google's bug

### DIFF
--- a/selector.gs
+++ b/selector.gs
@@ -106,5 +106,5 @@ function valuesMatch(value1, value2) {
  * Returns if a value is an object
  */
 function isObject (value) {
-  return value && typeof value === 'object' && value.constructor === Object;
+  return value && typeof value === 'object'; // add && value.constructor === Object if Google's bug is removed
 }


### PR DESCRIPTION
I have kind of Google's bug. I hope only I have it. Because of the bug Sheetfu throws the error 'Oops! Criteria should be an Array or an Object. Fix it and try again.' The function isObject( {"this is": "a real object"} ) returns false when you run this function **outside the Sheetfu project as library**. I paste my comment about it to here:
_Because of bug if you send an instance of Object to any function being in library, the object's constructor changes_
```
{ }.constructor === Object //true if this is running in your project
{ }.constructor === Object //false if this is running inside library, not in your project
```