### PR TITLE
Fix: `Table.select` bug running from V8 - Not detecting object

### DIFF
--- a/selector.gs
+++ b/selector.gs
@@ -106,5 +106,5 @@ function valuesMatch(value1, value2) {
  * Returns if a value is an object
  */
 function isObject (value) {
-  return value && typeof value === 'object' && value.constructor === Object;
+  return value && typeof value === 'object' && value.constructor.name === 'Object';
 }


### PR DESCRIPTION
As outlined in issues #48 #47 there is a bug when running the library from a script using the V8 runtime in GAS

This seems to be related to this issue outlined in the GAS docs on migrating to V8
https://developers.google.com/apps-script/guides/v8-runtime/migration#adjust_handling_of_instanceof_in_libraries

As such, update the problematic comparison in the `isObject` function
